### PR TITLE
✨ 세트옵션, 내부옵션, 세부옵션 추가기능 구현 완료, 💄옵션 추가할 시 유동적으로 박스 크기 늘어나도록스타일링 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8512,6 +8512,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
       "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA=="
     },
+    "react-icons": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ=="
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.3.1",
     "react-scripts": "5.0.0",
     "styled-components": "^5.3.3",
     "uuid": "^8.3.2",

--- a/src/components/Layouts/SectionBlock.jsx
+++ b/src/components/Layouts/SectionBlock.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { STYLE, COLOR } from 'constants';
 
-export const SectionBlock = ({ title, children, bg }) => {
+export const SectionBlock = ({ bg, title, children }) => {
   return (
     <SectionBlockContainer>
       <SectionTitle>{title}</SectionTitle>
@@ -12,6 +12,7 @@ export const SectionBlock = ({ title, children, bg }) => {
 };
 
 const SectionBlockContainer = styled.section`
+  position: relative;
   border: ${STYLE.BORDER};
   & + section {
     margin-top: 20px;

--- a/src/components/ProductOption/AdditionalOption.jsx
+++ b/src/components/ProductOption/AdditionalOption.jsx
@@ -1,0 +1,38 @@
+import { Input } from 'components';
+import React from 'react';
+import styled from 'styled-components';
+import { DeleteButton } from './DeleteButton';
+export const AdditionalOption = () => {
+  return (
+    <AddOptBox>
+      <li>
+        <Input placeholder={'추가 옵션명 (필수)'} fontS />
+      </li>
+      <li>
+        <Input placeholder={'추가 옵션 정상가 (필수)'} fontS />
+        <span>원</span>
+      </li>
+      <DeleteButton />
+    </AddOptBox>
+  );
+};
+
+const AddOptBox = styled.ul`
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+  li {
+    display: flex;
+    align-items: center;
+  }
+  li:first-child {
+    width: 35%;
+    margin-right: 1rem;
+  }
+  li:nth-child(2) {
+    width: 35%;
+  }
+  span {
+    margin-left: 0.5rem;
+  }
+`;

--- a/src/components/ProductOption/DeleteButton.jsx
+++ b/src/components/ProductOption/DeleteButton.jsx
@@ -1,0 +1,16 @@
+import { COLOR } from 'constants';
+import React from 'react';
+import styled from 'styled-components';
+
+export const DeleteButton = () => {
+  return <DelBtn>삭제</DelBtn>;
+};
+const DelBtn = styled.button`
+  display: block;
+  height: 2rem;
+  width: 4rem;
+  border-radius: 5px;
+  line-height: 2rem;
+  color: ${COLOR.RED};
+  border: 1px solid ${COLOR.RED};
+`;

--- a/src/components/ProductOption/InnerOption.jsx
+++ b/src/components/ProductOption/InnerOption.jsx
@@ -1,5 +1,4 @@
 import { Input } from 'components';
-import { COLOR } from 'constants';
 import { STYLE } from 'constants';
 import React, { useState } from 'react';
 import styled from 'styled-components';
@@ -13,12 +12,6 @@ export const InnerOption = ({ innerCount, setInnerCount }) => {
     let countArr = [...additionCount];
     countArr.push(Math.random());
     setAdditionCount(countArr);
-  };
-  const addInnerOption = () => {
-    let countArr = [...innerCount];
-    countArr.push(Math.random());
-    setInnerCount(countArr);
-    return;
   };
   return (
     <InnerOptionBox>
@@ -50,7 +43,6 @@ export const InnerOption = ({ innerCount, setInnerCount }) => {
       {additionCount.map(el => (
         <AdditionalOption key={el} />
       ))}
-      <AddButton onClick={addInnerOption}>+ 옵션 추가</AddButton>
     </InnerOptionBox>
   );
 };
@@ -60,23 +52,20 @@ const InnerOptionBox = styled.div`
   flex-direction: column;
   justify-content: space-evenly;
   width: 100%;
-  height: 50%;
+  height: 100%;
   padding: 0.5em;
   border: ${STYLE.BORDER};
   border-radius: 5px;
   & > button {
     margin-left: auto;
   }
+  & > *:not(:first-child) {
+    margin-bottom: 1rem;
+  }
+  & + div {
+    margin-top: 1rem;
+  }
 `;
-// const DeleteButton = styled.button`
-//   display: block;
-//   height: 2rem;
-//   width: 4rem;
-//   border-radius: 5px;
-//   color: ${COLOR.RED};
-//   border: 1px solid ${COLOR.RED};
-//   margin-left: auto;
-// `;
 const SecondLineOption = styled.ul`
   display: flex;
   align-items: center;
@@ -105,10 +94,4 @@ const SelectBox = styled.select`
   display: flex;
   width: 6rem;
   height: 3rem;
-`;
-const AddButton = styled.button`
-  width: 100%;
-  padding: 1em;
-  border: 1px solid ${COLOR.MAIN};
-  color: ${COLOR.MAIN};
 `;

--- a/src/components/ProductOption/InnerOption.jsx
+++ b/src/components/ProductOption/InnerOption.jsx
@@ -7,12 +7,18 @@ import { AdditionalOption } from './AdditionalOption';
 import { AiOutlinePlusSquare } from 'react-icons/ai';
 import { DeleteButton } from './DeleteButton';
 
-export const InnerOption = () => {
+export const InnerOption = ({ innerCount, setInnerCount }) => {
   const [additionCount, setAdditionCount] = useState([]);
   const addSemiOption = () => {
     let countArr = [...additionCount];
     countArr.push(Math.random());
     setAdditionCount(countArr);
+  };
+  const addInnerOption = () => {
+    let countArr = [...innerCount];
+    countArr.push(Math.random());
+    setInnerCount(countArr);
+    return;
   };
   return (
     <InnerOptionBox>
@@ -38,13 +44,13 @@ export const InnerOption = () => {
         </SelectBox>
       </SecondLineOption>
       <AddSemiOption>
-        <AiOutlinePlusSquare />
+        <AiOutlinePlusSquare onClick={addSemiOption} />
         <span>추가 옵션 상품 추가</span>
       </AddSemiOption>
       {additionCount.map(el => (
         <AdditionalOption key={el} />
       ))}
-      <AddButton onClick={addSemiOption}>+ 옵션 추가</AddButton>
+      <AddButton onClick={addInnerOption}>+ 옵션 추가</AddButton>
     </InnerOptionBox>
   );
 };

--- a/src/components/ProductOption/InnerOption.jsx
+++ b/src/components/ProductOption/InnerOption.jsx
@@ -1,0 +1,108 @@
+import { Input } from 'components';
+import { COLOR } from 'constants';
+import { STYLE } from 'constants';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { AdditionalOption } from './AdditionalOption';
+import { AiOutlinePlusSquare } from 'react-icons/ai';
+import { DeleteButton } from './DeleteButton';
+
+export const InnerOption = () => {
+  const [additionCount, setAdditionCount] = useState([]);
+  const addSemiOption = () => {
+    let countArr = [...additionCount];
+    countArr.push(Math.random());
+    setAdditionCount(countArr);
+  };
+  return (
+    <InnerOptionBox>
+      <DeleteButton />
+      <Input placeholder={'옵션명을 입력해 주세요'} fontS />
+      <SecondLineOption>
+        <li>
+          <Input placeholder={'상품 정상가 (필수)'} fontS />
+          <span>원</span>
+        </li>
+        <li>할인율%</li>
+        <li>
+          <Input placeholder={'상품 판매가 (필수)'} fontS />
+          <span>원</span>
+        </li>
+        <li>
+          <Input placeholder={'재고 (필수)'} fontS />
+          <span>개</span>
+        </li>
+        <SelectBox name="tax">
+          <option value="taxFree">비과세</option>
+          <option value="tax">과세</option>
+        </SelectBox>
+      </SecondLineOption>
+      <AddSemiOption>
+        <AiOutlinePlusSquare />
+        <span>추가 옵션 상품 추가</span>
+      </AddSemiOption>
+      {additionCount.map(el => (
+        <AdditionalOption key={el} />
+      ))}
+      <AddButton onClick={addSemiOption}>+ 옵션 추가</AddButton>
+    </InnerOptionBox>
+  );
+};
+
+const InnerOptionBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  width: 100%;
+  height: 50%;
+  padding: 0.5em;
+  border: ${STYLE.BORDER};
+  border-radius: 5px;
+  & > button {
+    margin-left: auto;
+  }
+`;
+// const DeleteButton = styled.button`
+//   display: block;
+//   height: 2rem;
+//   width: 4rem;
+//   border-radius: 5px;
+//   color: ${COLOR.RED};
+//   border: 1px solid ${COLOR.RED};
+//   margin-left: auto;
+// `;
+const SecondLineOption = styled.ul`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  li {
+    display: flex;
+    align-items: center;
+  }
+  span {
+    margin-left: 0.5rem;
+  }
+`;
+const AddSemiOption = styled.div`
+  display: flex;
+  align-items: center;
+  svg {
+    font-size: 1.3rem;
+    width: 2rem;
+    cursor: pointer;
+  }
+  span {
+    transform: translateY(1px);
+  }
+`;
+const SelectBox = styled.select`
+  display: flex;
+  width: 6rem;
+  height: 3rem;
+`;
+const AddButton = styled.button`
+  width: 100%;
+  padding: 1em;
+  border: 1px solid ${COLOR.MAIN};
+  color: ${COLOR.MAIN};
+`;

--- a/src/components/ProductOption/OptionImage.jsx
+++ b/src/components/ProductOption/OptionImage.jsx
@@ -15,7 +15,8 @@ const ImageBox = styled.div`
   align-items: center;
   justify-content: center;
   width: 100%;
-  height: 50%;
+  min-height: 20rem;
+  height: 100%;
   margin-bottom: 1rem;
   padding: 0.5em;
   background-color: ${COLOR.BG};

--- a/src/components/ProductOption/OptionImage.jsx
+++ b/src/components/ProductOption/OptionImage.jsx
@@ -1,0 +1,30 @@
+import { COLOR } from 'constants';
+import React from 'react';
+import styled from 'styled-components';
+
+export const OptionImage = () => {
+  return (
+    <ImageBox>
+      <AddImageButton>+ 이미지 첨부</AddImageButton>
+    </ImageBox>
+  );
+};
+
+const ImageBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 50%;
+  margin-bottom: 1rem;
+  padding: 0.5em;
+  background-color: ${COLOR.BG};
+`;
+const AddImageButton = styled.button`
+  padding: 1em;
+  width: 15rem;
+  height: 4rem;
+  border: 1px solid ${COLOR.MAIN};
+  color: ${COLOR.MAIN};
+  border-radius: 5px;
+`;

--- a/src/components/ProductOption/OptionMain.jsx
+++ b/src/components/ProductOption/OptionMain.jsx
@@ -1,0 +1,52 @@
+import { COLOR } from 'constants';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { OptionSet } from './OptionSet';
+
+const OptionMain = () => {
+  const [optionSetCount, setOptionSetCount] = useState([]);
+  const handleClick = () => {
+    let setCountArr = [...optionSetCount];
+    setCountArr.push(Math.random());
+    setOptionSetCount(setCountArr);
+  };
+  return (
+    <>
+      <MainContainer>
+        {optionSetCount.length === 0 ? (
+          <NoOptionText>옵션세트를 추가하여 옵션을 구성해 주세요.</NoOptionText>
+        ) : (
+          optionSetCount.map(el => (
+            <OptionSet key={el} setOptionSetCount={setOptionSetCount} />
+          ))
+        )}
+      </MainContainer>
+      <AddOptionSetBtn onClick={handleClick}>+ 옵션 세트 추가</AddOptionSetBtn>
+    </>
+  );
+};
+
+export default OptionMain;
+
+const MainContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 6em 0;
+  width: 100%;
+  height: 30rem;
+  overflow-y: scroll;
+`;
+const NoOptionText = styled.span`
+  position: absolute;
+  top: 40%;
+  font-size: 1.3rem;
+`;
+const AddOptionSetBtn = styled.button`
+  position: absolute;
+  border: 1px solid ${COLOR.MAIN};
+  color: ${COLOR.MAIN};
+  padding: 13.5px 0.5em;
+  top: 0;
+  right: 0;
+`;

--- a/src/components/ProductOption/OptionSet.jsx
+++ b/src/components/ProductOption/OptionSet.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+import { InnerOption } from './InnerOption';
+import { OptionImage } from './OptionImage';
+import { DeleteButton } from './DeleteButton';
+
+export const OptionSet = ({ setOptionSetCount }) => {
+  const handleDelete = () => {
+    setOptionSetCount(count => count - 1);
+    console.log('clicked!');
+  };
+  return (
+    <>
+      <SetContainer>
+        <OptionImage />
+        <InnerOption />
+        <DeleteButton onClick={handleDelete} />
+      </SetContainer>
+    </>
+  );
+};
+
+const SetContainer = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 90%;
+  height: 50rem;
+  padding: 1em;
+  background-color: #fff;
+  flex-shrink: 0;
+  border-radius: 5px;
+  box-shadow: 0px 4px 10px 0px rgba(0, 0, 0, 0.75);
+  &:not(:last-child) {
+    margin-bottom: 7rem;
+  }
+  & > button {
+    position: absolute;
+    top: -5%;
+    right: 0;
+  }
+`;

--- a/src/components/ProductOption/OptionSet.jsx
+++ b/src/components/ProductOption/OptionSet.jsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { InnerOption } from './InnerOption';
 import { OptionImage } from './OptionImage';
 import { DeleteButton } from './DeleteButton';
 
 export const OptionSet = ({ setOptionSetCount }) => {
+  const [innerCount, setInnerCount] = useState([0]);
   const handleDelete = () => {
     setOptionSetCount(count => count - 1);
     console.log('clicked!');
@@ -13,7 +14,9 @@ export const OptionSet = ({ setOptionSetCount }) => {
     <>
       <SetContainer>
         <OptionImage />
-        <InnerOption />
+        {innerCount.map(el => (
+          <InnerOption innerCount={innerCount} setInnerCount={setInnerCount} />
+        ))}
         <DeleteButton onClick={handleDelete} />
       </SetContainer>
     </>

--- a/src/components/ProductOption/OptionSet.jsx
+++ b/src/components/ProductOption/OptionSet.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { InnerOption } from './InnerOption';
 import { OptionImage } from './OptionImage';
 import { DeleteButton } from './DeleteButton';
+import { COLOR } from 'constants';
 
 export const OptionSet = ({ setOptionSetCount }) => {
   const [innerCount, setInnerCount] = useState([0]);
@@ -10,14 +11,25 @@ export const OptionSet = ({ setOptionSetCount }) => {
     setOptionSetCount(count => count - 1);
     console.log('clicked!');
   };
+  const addInnerOption = () => {
+    let countArr = [...innerCount];
+    countArr.push(Math.random());
+    setInnerCount(countArr);
+    return;
+  };
   return (
     <>
       <SetContainer>
         <OptionImage />
         {innerCount.map(el => (
-          <InnerOption innerCount={innerCount} setInnerCount={setInnerCount} />
+          <InnerOption
+            key={el}
+            innerCount={innerCount}
+            setInnerCount={setInnerCount}
+          />
         ))}
         <DeleteButton onClick={handleDelete} />
+        <AddButton onClick={addInnerOption}>+ 옵션 추가</AddButton>
       </SetContainer>
     </>
   );
@@ -29,8 +41,8 @@ const SetContainer = styled.div`
   flex-direction: column;
   align-items: center;
   width: 90%;
-  height: 50rem;
-  padding: 1em;
+  min-height: 40rem;
+  padding: 1em 1em 4em 1em;
   background-color: #fff;
   flex-shrink: 0;
   border-radius: 5px;
@@ -38,9 +50,19 @@ const SetContainer = styled.div`
   &:not(:last-child) {
     margin-bottom: 7rem;
   }
-  & > button {
+  & > button:not(:last-child) {
     position: absolute;
-    top: -5%;
+    top: -7%;
     right: 0;
   }
+`;
+const AddButton = styled.button`
+  position: absolute;
+  bottom: 1%;
+  width: 98.5%;
+  height: 3rem;
+  padding: 1em;
+  border-radius: 5px;
+  border: 1px solid ${COLOR.MAIN};
+  color: ${COLOR.MAIN};
 `;

--- a/src/components/ProductOption/index.js
+++ b/src/components/ProductOption/index.js
@@ -1,0 +1,1 @@
+export { default as OptionMain } from './OptionMain.jsx';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -4,6 +4,7 @@ export const COLOR = {
   TAG: '#E8F7D4',
   BG: '#E3E3E3',
   BG_LIGHT: '#EFEFEF',
+  RED: '#DD3534',
 };
 
 export const STYLE = {

--- a/src/pages/ProductRegist.jsx
+++ b/src/pages/ProductRegist.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
+import BasicInformation from 'pages/jy';
 import InformationFilter from './hh';
-import BasicInformation from './jy';
 import { PageBlock } from 'components/Layouts';
+import ProductOption from 'pages/hj';
 
 const ProductRegist = () => {
   return (
     <PageBlock title="상품 등록">
       <BasicInformation />
       <InformationFilter />
+      <ProductOption />
     </PageBlock>
   );
 };

--- a/src/pages/hj.jsx
+++ b/src/pages/hj.jsx
@@ -1,7 +1,13 @@
+import { SectionBlock } from 'components/Layouts';
+import { OptionMain } from 'components/ProductOption';
 import React from 'react';
 
-const hj = () => {
-  return <div></div>;
+const ProductOption = () => {
+  return (
+    <SectionBlock title="상품 옵션" bg>
+      <OptionMain />
+    </SectionBlock>
+  );
 };
 
-export default hj;
+export default ProductOption;


### PR DESCRIPTION
## 세부 사항
- OptionSet컴포넌트와 innderOption 컴포넌트의 key값 겹침 문제 해결하였습니다.
- 각각 주어진 세트옵션, 내부옵션, 세부옵션 추가 버튼 클릭 시 -> 옵션 추가되도록 기능 구현 완료하였습니다.
- 옵션이 추가될 시, 박스 크기가 유동적으로 늘어나지 않았었으나, CSS수정하여 늘어나도록 구현 완료했습니다.

## 기타 질문 및 특이 사항
- 진짜 배열이 아닌, 가짜 배열을 만든 후  map을 돌려 컴포넌트를 생성해줘야 했는데 이 때문에 key값에 Math.random()을 넣어줬음
- 추가, 삭제 할 때마다 배열이 줄어들고 늘어나는 것 util함수로 빼두면 좋을 것 같아 삭제 기능 구현 후 해당 작업 진행 할 예정
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.